### PR TITLE
Archiving, Unarchiving, and Deleting Events

### DIFF
--- a/css/event.css
+++ b/css/event.css
@@ -588,8 +588,10 @@ td {
     border-radius: 4px;
 }
 
+/* shouldn't we keep cancel as grey? We have red buttons already using "button.danger"
 .button.cancel {
     background-color: #dc3545;
 }
+*/
 
 

--- a/database/dbEvents.php
+++ b/database/dbEvents.php
@@ -82,7 +82,10 @@ function sign_up_for_event($eventID, $account_name, $role, $notes) {
         return $value;
     }
 
-/*@@@ Check if a user is is signed up for an event. Return true or false. */
+/* @@@ Thomas's work! */
+/*
+ * Check if a user is is signed up for an event. Return true or false.
+ */
 function check_if_signed_up($eventID, $userID) {
     // look up event+user pair
     $connection = connect();
@@ -98,7 +101,52 @@ function check_if_signed_up($eventID, $userID) {
         return False;
     }
 }
-/**/
+
+
+/*
+ * Returns true if the given event is archived.
+ */
+function is_archived($id) {
+    // look-up 'completed' in the event's DB entry
+    $connection = connect();
+    $query1 = "SELECT completed FROM dbevents WHERE id = '$id'";
+    $result1 = mysqli_query($connection, $query1);
+    $row = mysqli_fetch_assoc($result1);
+    mysqli_close($connection);
+
+    if ($row == NULL) return False; // no match for that event ID
+
+    if ($row['completed'] == 'yes') {
+        // event is archived
+        return True;
+    } else {
+        return False;
+    }
+}
+
+/*
+ * Mark an event as archived in the DB by setting the 'completed' column to 'yes'.
+ */
+function archive_event($id) {
+    $con=connect();
+    $query = "UPDATE dbevents SET completed = 'yes' WHERE id = '" .$id. "'";
+    $result = mysqli_query($con, $query);
+    mysqli_close($con);
+    return $result;
+}
+
+/*
+ * Mark an event as not archived in the DB by setting the 'completed' column to 'no'.
+ */
+function unarchive_event($id) {
+    $con=connect();
+    $query = "UPDATE dbevents SET completed = 'no' WHERE id = '" .$id. "'";
+    $result = mysqli_query($con,$query);
+    mysqli_close($con);
+    return $result;
+}
+
+/* end of Thomas's work*/
 
 /*
  * remove an event from dbEvents table.  If already there, return false

--- a/event.php
+++ b/event.php
@@ -209,6 +209,16 @@
                     check_out($personID, $eventID, $timestamp);
                     echo "<div class='happy-toast'>You've checked out!</div>";
                 }
+                else if (isset($_POST['archiving'])) {
+                    $eventID = $_POST['eventID'];
+                    archive_event($eventID);
+                    echo "<div class='happy-toast'>Event has been archived!</div>";
+                }
+                else if (isset($_POST['unarchiving'])) {
+                    $eventID = $_POST['eventID'];
+                    unarchive_event($eventID);
+                    echo "<div class='happy-toast'>Event has been unarchived!</div>";
+                }
             }
         ?>
         <!---->
@@ -301,15 +311,34 @@
                     <button type="submit" class="button danger">Check-Out</button>
                 </form>
             <?php endif ?>
-            <!---->
+
+            <!-- end of Thomas's work-->
 
             <?php if ($access_level >= 2) : ?>
-                <a href="editEvent.php?id=<?= $id ?>" class="button success">Edit Event Details</a>
-                <?php if ($event_info["completed"] == "no") : ?>
-                    <button onclick="showCompleteConfirmation()" class="button success">Complete Appointment</button>
-                <?php endif ?>
+
+                <a href="editEvent.php?id=<?= $id ?>" class="button">Edit Event Details</a>
+
+                <!-- Thomas's work -->
+
+                <?php if (is_archived($event_info['id']))  : ?>
+                    <form method="POST" action="">
+                    <input type="hidden" name="unarchiving" value="1">
+                    <input type="hidden" name="eventID" value="<?php echo $event_info['id']; ?>">
+                    <button type="submit" class="button">Unarchive</button>
+                </form>
+
+                <?php else : ?>
+                    <form method="POST" action="">
+                    <input type="hidden" name="archiving" value="1">
+                    <input type="hidden" name="eventID" value="<?php echo $event_info['id']; ?>">
+                    <button type="submit" class="button">Archive</button>                <?php endif ?>
+
+                <!-- end of Thomas's work -->
+
                 <button onclick="showDeleteConfirmation()" class="button danger">Delete Event</button>
+
             <?php endif ?>
+            
             <a href="calendar.php?month=<?= substr($event_info['date'], 0, 7) ?>" class="button cancel">Return to Calendar</a>
         </div>
 
@@ -317,10 +346,10 @@
         <?php if ($access_level >= 2) : ?>
             <div id="delete-confirmation-wrapper" class="modal hidden">
                 <div class="modal-content">
-                    <p>Are you sure you want to delete this appointment?</p>
+                    <p>Are you sure you want to delete this event?</p>
                     <p>This action cannot be undone.</p>
                     <form method="post" action="deleteEvent.php">
-                        <input type="submit" value="Delete Appointment" class="button danger">
+                        <input type="submit" value="Delete Event" class="button danger">
                         <input type="hidden" name="id" value="<?= $id ?>">
                     </form>
                     <button id="delete-cancel" class="button cancel">Cancel</button>
@@ -329,10 +358,10 @@
 
             <div id="complete-confirmation-wrapper" class="modal hidden">
                 <div class="modal-content">
-                    <p>Are you sure you want to complete this appointment?</p>
-                    <p>This action cannot be undone.</p>
+                    <p>Are you sure you want to archive this event?</p>
+                    <p>Users will no longer have acces to this event. It can always be unarchived later.</p>
                     <form method="post" action="completeEvent.php">
-                        <input type="submit" value="Complete Appointment" class="button success">
+                        <input type="submit" value="Archive Event" class="button">
                         <input type="hidden" name="id" value="<?= $id ?>">
                     </form>
                     <button id="complete-cancel" class="button cancel">Cancel</button>

--- a/event.php
+++ b/event.php
@@ -318,27 +318,29 @@
 
                 <a href="editEvent.php?id=<?= $id ?>" class="button">Edit Event Details</a>
 
-                <!-- Thomas's work -->
+                <!-- Archive and Unarchive buttons by Thomas -->
 
                 <?php if (is_archived($event_info['id']))  : ?>
-                    <form method="POST" action="">
-                    <input type="hidden" name="unarchiving" value="1">
-                    <input type="hidden" name="eventID" value="<?php echo $event_info['id']; ?>">
-                    <button type="submit" class="button">Unarchive</button>
-                </form>
+                    <form method="POST" action="" onsubmit="return confirmAction('unarchive')">
+                        <input type="hidden" name="unarchiving" value="1">
+                        <input type="hidden" name="eventID" value="<?php echo $event_info['id']; ?>">
+                        <button type="submit" class="button">Unarchive</button>
+                    </form>
 
                 <?php else : ?>
-                    <form method="POST" action="">
-                    <input type="hidden" name="archiving" value="1">
-                    <input type="hidden" name="eventID" value="<?php echo $event_info['id']; ?>">
-                    <button type="submit" class="button">Archive</button>                <?php endif ?>
+                    <form method="POST" action="" onsubmit="return confirmAction('archive')">
+                        <input type="hidden" name="archiving" value="1">
+                        <input type="hidden" name="eventID" value="<?php echo $event_info['id']; ?>">
+                        <button type="submit" class="button">Archive</button>
+                    </form>
+                <?php endif ?>
 
                 <!-- end of Thomas's work -->
 
                 <button onclick="showDeleteConfirmation()" class="button danger">Delete Event</button>
 
             <?php endif ?>
-            
+
             <a href="calendar.php?month=<?= substr($event_info['date'], 0, 7) ?>" class="button cancel">Return to Calendar</a>
         </div>
 


### PR DESCRIPTION
Admin is now able to delete events, as well as toggle an event between archived and unarchived. Archived events still appear as grey on the calendar.

We should consider only displaying archived events on the admin calendar, and hiding them on the user's calendar.